### PR TITLE
Align EM docs with IH Key Competencies guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ See [ADR-0006](decision-records/0006-job-description-format.md).
 Content across both documents and both tracks should reflect the seven engineering principles defined in [engineering-principles.md](engineering-principles.md).
 When writing or reviewing role content, check that the principles are represented appropriately for the level.
 
+Role content should also align with the company's eight Key Competencies, summarized in [key_competencies.md](key_competencies.md).
+Where the competencies define specific language or behaviors, prefer that vocabulary in role documents.
+The summary includes expected behaviors at two levels: **Associate** (IC track) and **People Leader** (management track).
+
 ### Front Matter
 
 Every page requires Jekyll front matter with `id` (hyphenated slug) and `title`.

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ exclude:
   - CLAUDE.md
   - README.md
   - style-guide.md
+  - key_competencies.md
 remote_theme: invitation-homes/career-progression-framework-theme@main
 search_enabled: false
 sidebar:

--- a/being-a/being-an-engineering-manager.md
+++ b/being-a/being-an-engineering-manager.md
@@ -107,17 +107,13 @@ Resources for running effective one-on-ones are documented in the Engineering sp
 ### Leading Through Change
 
 Change is a constant.
-Your team will face new tools, new processes, and new organizational direction.
-Sometimes all at once.
-Your job isn't to absorb the change silently and reassign tickets.
-It's to help your team move through it with clarity and care.
+Your team will face new tools, new processes, and new organizational direction, sometimes all at once.
+Your job isn't to absorb it silently and reassign tickets; it's to help your team move through it with clarity and care.
 
-Explain what is changing in plain language: the why, the impact, and the next steps.
-Create a simple plan with clear owners, dates, and checkpoints.
-Coach individuals through the transition and adjust based on feedback.
-Monitor adoption: don't assume things are working because no one has complained.
-Close the loops.
-Recognize progress, and address concerns quickly when they surface.
+Start by explaining what's changing in plain language: the why, the impact, and the next steps.
+Create a simple plan with clear owners, dates, and checkpoints, then stay close as the team adapts.
+Monitor adoption actively; a quiet team isn't always a team that's on board.
+Adjust based on what you hear, recognize progress when it happens, and address concerns quickly when they surface.
 
 The resident and associate experience doesn't stop during a transition.
 Protect it.

--- a/being-a/being-an-engineering-manager.md
+++ b/being-a/being-an-engineering-manager.md
@@ -71,6 +71,8 @@ You are also an ally and advocate for your team: representing their interests to
 ### Live Our Principles and Build Our Culture
 
 You are expected to live our [engineering principles](../engineering-principles), model them for your pod, and encourage the team to follow them — or at least aspire to.
+Those principles complement the company's eight Key Competencies: the behaviors that define how every Invitation Homes associate thinks, communicates, makes decisions, and drives results.
+As a People Leader in that framework, you're not just modeling these behaviors; you're developing them in your team.
 One principle worth calling out explicitly: speak up when you disagree.
 Your voice matters, and holding back a concern doesn't serve the team.
 But once a decision is made, commit fully so the team can succeed as one.
@@ -101,6 +103,24 @@ We believe, and research backs this up, that managers need a deep commitment to 
 The most direct way to demonstrate that is by investing time each week in your direct reports.
 One-on-ones are your primary vehicle for coaching, your best signal on individual health, and your early warning system when something is off.
 Resources for running effective one-on-ones are documented in the Engineering space in Confluence.
+
+### Leading Through Change
+
+Change is a constant.
+Your team will face new tools, new processes, and new organizational direction.
+Sometimes all at once.
+Your job isn't to absorb the change silently and reassign tickets.
+It's to help your team move through it with clarity and care.
+
+Explain what is changing in plain language: the why, the impact, and the next steps.
+Create a simple plan with clear owners, dates, and checkpoints.
+Coach individuals through the transition and adjust based on feedback.
+Monitor adoption: don't assume things are working because no one has complained.
+Close the loops.
+Recognize progress, and address concerns quickly when they surface.
+
+The resident and associate experience doesn't stop during a transition.
+Protect it.
 
 ### Performance Reviews
 

--- a/engineering-manager.md
+++ b/engineering-manager.md
@@ -14,7 +14,8 @@ Think of yourself as a player-coach — equally invested in the technical work a
 
 - Cultivate teams through relationships, culture, recruiting, and growth within your Engineering pod.
 - Use domain knowledge to plan and drive delivery of solutions aligned with business goals.
-- Facilitate the team’s execution by identifying and removing obstacles, improving processes, collaboration, and prioritization.
+- Facilitate the team’s execution by anticipating and removing obstacles, improving processes, collaboration, and prioritization.
+  Take ownership when the team falls short.
 - Own the health of your team's systems — advocate for reliability, maintainability, and automation alongside delivery.
 - Evaluate technical risk and help your team make sound decisions, even when the path forward isn't clear.
 
@@ -35,20 +36,25 @@ You share knowledge, influence culture, and support consistency across the broad
   You are capable of diving deep to help unblock, troubleshoot, or guide.
 - Anticipate future technical and organizational challenges, and steer the team toward scalable and sustainable approaches.
 - Maintain deep understanding of the tools and processes across both engineering and management practices.
-- Understand how your team’s work connects to company strategy, customer experience, and business metrics.
+- Connect your team’s responsibilities to KPIs, resident and associate experience, and business metrics.
+  Use data, dashboards, and metrics to guide decisions and prioritize work.
 
 ## Communication
 
 - Communicate clearly, proactively, and transparently with your team, stakeholders, and partners.
-- Translate technical concepts for non-technical audiences and vice versa.
+- Tailor your message to the audience: translate technical, financial, or policy complexity into clear actions, state the why and the impact, and confirm understanding.
 - Provide thoughtful feedback that promotes alignment and action.
 - Resolve ambiguity and conflict constructively and encourage healthy team discussions and decision-making.
+- When delegating, clearly articulate what you're delegating, why, and to whom.
 
 ## Leadership
 
 - Cultivate a high-performing, inclusive, and psychologically safe team environment.
-- Provide coaching, mentorship, and guidance to help engineers grow in their careers.
-- Manage performance with clarity and care — address gaps early and invest in growth before it becomes a problem.
+- Coach regularly and give clear, specific feedback that builds skills.
+  Create development plans and stretch opportunities tied to team needs, track follow-through on development actions, and address performance gaps early.
 - Lead hiring end-to-end: build strong pipelines, represent Invitation Homes well to candidates, and champion a great candidate and new hire experience.
 - Delegate effectively, trust your team, and hold them accountable for their commitments.
+- Hold the team to ethical and compliance standards: protect data and privacy, model fairness in how work and opportunities are distributed, and address interpersonal conflicts early.
+- When leading the team through change (new tools, processes, or direction), explain what is changing in plain language: the why, the impact, and the next steps.
+  Create a plan with clear owners and checkpoints, coach the team through the transition, and monitor adoption.
 - Model the values and behaviors you want to see across the organization: curiosity, humility, a bias to action, and genuine care for others.

--- a/engineering-manager.md
+++ b/engineering-manager.md
@@ -45,7 +45,7 @@ You share knowledge, influence culture, and support consistency across the broad
 - Tailor your message to the audience: translate technical, financial, or policy complexity into clear actions, state the why and the impact, and confirm understanding.
 - Provide thoughtful feedback that promotes alignment and action.
 - Resolve ambiguity and conflict constructively and encourage healthy team discussions and decision-making.
-- When delegating, clearly articulate what you're delegating, why, and to whom.
+- When delegating, clearly articulate what you're delegating, why, to whom, and what success looks like.
 
 ## Leadership
 

--- a/engineering-principles.md
+++ b/engineering-principles.md
@@ -19,6 +19,9 @@ Our engineering vision and mission support the company's purpose and values, kee
 Our Engineering Principles are a reflection of the culture we aspire to build and the behaviors we want to reinforce across our teams.
 They serve as a north star for how we operate, make decisions, and grow as engineers.
 
+These principles align with Invitation Homes' core values framework, Genuine CARE: **C**onnect the Dots, **A**im True, **R**aise the Roof, and **E**mbrace the Journey.
+They also complement the company's Key Competencies, which set eight behaviors expected of every Invitation Homes associate; our engineering principles translate several of them into engineering-specific practice.
+
 The principles are designed to:
 
 - Guide decision-making at all levels of engineering.
@@ -26,8 +29,6 @@ The principles are designed to:
 - Promote individual growth.
 - Encourage shared ownership of what "good" engineering looks like.
 - Create alignment across teams, so we're all moving toward the same goals.
-
-These principles align with Invitation Homes' core values framework, Genuine CARE: **C**onnect the Dots, **A**im True, **R**aise the Roof, and **E**mbrace the Journey.
 
 ### Our Principles
 

--- a/job-descriptions/engineering-manager.md
+++ b/job-descriptions/engineering-manager.md
@@ -32,7 +32,7 @@ From here, you'll have a clear path to Sr. Engineering Manager as your leadershi
 **Knowledge & Standards**
 
 - Maintain a deep understanding of your team's systems, technical stack, and the challenges they face.
-- Understand how your team's work connects to business goals, customer experience, and company strategy.
+- Understand how your team's work connects to business goals, resident and associate experience, and company strategy.
 - Use delivery data, team health signals, and engineering metrics to understand what's working and what needs attention.
 - Stay current in engineering and management practices — bring what you learn back to your team and your peers.
 
@@ -42,14 +42,19 @@ From here, you'll have a clear path to Sr. Engineering Manager as your leadershi
 - Translate technical context for non-technical partners, and business context for your engineers.
 - Provide feedback — to your team and upward — that is clear, specific, and actionable.
 - Resolve ambiguity and conflict constructively; create space for healthy disagreement and clear, committed action.
+- Tailor your message to the audience: state the why, the impact, and a clear next step, then confirm understanding.
 
 **Leadership & Culture**
 
 - Build a high-performing, inclusive, and psychologically safe environment where engineers can do their best work.
-- Coach and develop your engineers through regular 1:1s, goal-setting, and deliberate career growth conversations.
+- Coach regularly and give clear, specific feedback that builds skills.
+  Create development plans and stretch opportunities tied to team needs, and track follow-through on development actions.
 - Manage performance with clarity and care — address gaps early and invest in growth before it becomes a problem.
 - Lead hiring end-to-end: build strong pipelines, represent Invitation Homes well to candidates, and champion a great candidate and new hire experience.
 - Delegate effectively, trust your team, and hold them accountable for their commitments.
+- Hold the team to ethical and compliance standards: protect data and privacy, model fairness in how work and opportunities are distributed, and address interpersonal conflicts early.
+- When leading your team through change, explain what is changing in plain language: the why, the impact, and what comes next.
+  Create a plan with owners and checkpoints, and monitor adoption.
 - Model the values and behaviors you want to see — curiosity, humility, a bias to action, and genuine care for others.
 
 ## What You Bring

--- a/job-descriptions/engineering-manager.md
+++ b/job-descriptions/engineering-manager.md
@@ -42,7 +42,7 @@ From here, you'll have a clear path to Sr. Engineering Manager as your leadershi
 - Translate technical context for non-technical partners, and business context for your engineers.
 - Provide feedback — to your team and upward — that is clear, specific, and actionable.
 - Resolve ambiguity and conflict constructively; create space for healthy disagreement and clear, committed action.
-- Tailor your message to the audience: state the why, the impact, and a clear next step, then confirm understanding.
+- Tailor your communication to the audience — translating technical context for non-technical partners and business context for your engineers.
 
 **Leadership & Culture**
 

--- a/key_competencies.md
+++ b/key_competencies.md
@@ -1,0 +1,121 @@
+---
+id: key-competencies
+title: IH Key Competencies
+---
+
+# IH Key Competencies
+
+Invitation Homes defines eight Key Competencies — the behaviors that describe how every associate thinks, communicates, makes decisions, and drives results.
+They are organized under the four company values: **Connect the Dots**, **Aim True**, **Raise the Roof**, and **Embrace the Journey**.
+
+This document summarizes the competencies and their expected behaviors at two levels:
+
+- **Associate** — individual contributors who deliver work and contribute to team success (maps to the IC track in this framework)
+- **People Leader** — managers who lead teams, develop talent, and connect work to strategy (maps to the management track)
+
+Use this as a reference when writing or reviewing role content, to ensure the language and expectations in the framework align with the company-wide vocabulary.
+
+---
+
+## Connect the Dots
+
+*Value: Transparency*
+
+### Business Acumen — Know the business, know your customer
+
+Understanding how your work supports residents, teammates, and the business.
+Use facts and context to make good choices, and explain how your actions tie to goals, costs, quality, and impact.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Understands how their work connects to team goals, KPIs, and resident experience; uses data in day-to-day decisions; asks questions to understand the "why" behind priorities; flags cost, quality, or risk impacts early |
+| People Leader | Connects team responsibilities to KPIs; uses data dashboards and metrics to guide decisions and prioritize work; identifies cost, risk, and resident/associate implications when allocating resources or structuring workloads |
+
+### Contextual Communication — Communicate with context and clarity
+
+Sharing information in a clear and thoughtful way so others can act with confidence.
+Explain the purpose, impact, and next steps, and tailor the message based on who needs the information and what they need to move forward.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Shares clear, timely updates with appropriate detail; confirms understanding and closes the loop; uses the right channel and tone for the audience; escalates time-sensitive issues early |
+| People Leader | Tailors communication for diverse audiences; translates technical, financial, or policy information into clear actions; clearly articulates what is being delegated, why, and to whom; states the why, the impact, and one clear next step, then confirms understanding |
+
+---
+
+## Aim True
+
+*Value: Reliability*
+
+### Accountability & Ownership — Own the outcome
+
+Taking responsibility for your work, your decisions, and the results you create.
+Follow through on commitments, speak up early when you need help, and learn from your experiences.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Takes ownership of assigned work from start to finish; flags barriers early and proposes options when possible; learns from mistakes and implements fixes to avoid repeat issues; completes work by agreed deadlines |
+| People Leader | Holds teams accountable for outputs; anticipates and addresses issues early; removes blockers and takes ownership when the team does not meet goals; ensures team performance supports resident experience, business continuity, and compliance standards |
+
+### Integrity & Ethics — Choose integrity, even when it's hard
+
+Doing the right thing in every situation.
+Make choices that build trust by being honest, fair, and respectful with residents and coworkers.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Follows policies, procedures, and requirements consistently; acts honestly and respectfully under pressure; protects confidential information and company assets; raises concerns when something seems unsafe, unfair, or unethical; asks for guidance in gray areas |
+| People Leader | Holds the team to compliance, privacy, safety, and ethical standards; models fairness in workload distribution and decision-making; partners with HR early on individual ethical issues; addresses interpersonal conflicts early |
+
+---
+
+## Raise the Roof
+
+*Value: Excellence*
+
+### Operational Excellence — Deliver meaningful results
+
+Completing work with quality, efficiency, and care for the resident and associate experience.
+Follow processes that keep the team consistent and look for smart, simple ways to solve problems.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Plans and prioritizes work to meet deadlines and service expectations; uses standard processes and checklists; documents work accurately; balances speed with quality and experience |
+| People Leader | Models standard work and showcases process improvement; monitors quality and accuracy; identifies root causes when issues repeat and coaches on improvements |
+
+### Innovation & Smart Risk — Innovate boldly
+
+Looking for better ways to work and being open to new ideas that improve results.
+Test small changes, learn from what works, and share ideas that help the team or the business move forward.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Suggests practical improvements; tests new ideas in a low-risk way with manager guidance; uses simple measures (time, cost, defects, feedback) to learn what works; shares learnings openly, including what did not work |
+| People Leader | Sponsors pilots with a clear success metric and before/after results; encourages associates to surface inefficiencies and propose practical solutions; supports ongoing pilots involving new tools or workflows; adopts proven tools and process changes quickly |
+
+---
+
+## Embrace the Journey
+
+*Value: Warmth*
+
+### Talent Development & Teaming — Make each other better
+
+Owning your growth and helping others succeed.
+Learn, ask for feedback, and share knowledge so the team gets better together.
+Contribute to a positive, inclusive environment where everyone can do their best work.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Seeks feedback and acts on it; uses SMART goals to track progress; shares knowledge and job aids with teammates; supports cross-training; contributes to an inclusive, respectful environment |
+| People Leader | Models learning by pursuing development goals and sharing progress; coaches regularly and gives clear, specific feedback that builds skills; creates development plans and stretch opportunities tied to team needs; builds an inclusive team where people help one another learn; tracks follow-through on development actions and removes barriers to growth |
+
+### Change Management & Resilience — Learn, adjust, and move forward together
+
+Being responsible for your response to change and helping others move through it with clarity and care.
+Stay open-minded, learn what is changing and why, and adjust your approach so work stays on track.
+
+| Level | Key behaviors |
+| --- | --- |
+| Associate | Adapts to new priorities, processes, and tools with a helpful mindset; asks questions to understand what is changing; shares clear updates and flags issues early; keeps performance steady and supports teammates during transitions |
+| People Leader | Explains the change in plain language: the why, the impact, and the next steps; creates a simple plan with owners, dates, and checkpoints; coaches the team through new ways of working and adjusts based on feedback; monitors adoption and closes loops; recognizes progress and addresses concerns quickly |

--- a/style-guide.md
+++ b/style-guide.md
@@ -59,17 +59,22 @@ See [ADR-0001](decision-records/0001-semantic-line-breaks) for the semantic line
 ### Rhythm
 
 Mix short and long sentences deliberately.
-Short sentences create emphasis and let ideas land.
-Long sentences carry explanation, context, and nuance.
-Never run three long sentences in a row without a short one to break them up.
+A short sentence creates emphasis and lets an idea land; a long sentence carries the explanation, nuance, and context that earns the landing.
+Neither works in isolation.
+Never run three long sentences in a row without a short one to break them up, and never cluster short sentences until the prose flattens into a list.
+Short sentences land because they follow something longer.
+Used in clusters, they lose their punch.
 
 **Works:**
 > You lead the leaders.
 > Your direct reports are Engineering Managers.
 > The lever has shifted from writing code to building the organizational conditions — the structure, culture, and leadership capacity — that let multiple teams operate well at once.
 
-**Does not work:**
+**Does not work — too many long sentences:**
 > As a Director of Engineering, you are responsible for the strategic technical vision of your operating group, including the management of engineering managers, the alignment of technical decisions with business strategy, and the cultivation of a high-performance culture across multiple cross-functional teams.
+
+**Does not work — too many short sentences:**
+> Change is a constant. Your team will face new tools. Sometimes all at once. Your job isn't to absorb it. It's to help your team move through it. Explain what is changing. Create a plan. Close the loops.
 
 ### Active voice
 
@@ -133,6 +138,7 @@ When you have explained something complex, land it with a short sentence.
 > "Context that lives in people's heads leaves when they do."
 > "The best time to address an organizational gap is before you feel it."
 > "When we get it right, people feel it."
+The power is in the contrast with what came before. Used back to back, the emphasis dissolves.
 
 **External attribution format.**
 Blockquote with an attribution line:

--- a/style-guide.md
+++ b/style-guide.md
@@ -197,6 +197,9 @@ Do not use euphemism or corporate softening for hard realities.
 Use these terms consistently.
 Introducing synonyms creates noise.
 
+Where the company's Key Competencies define specific language for a behavior or expectation, use that language.
+The competencies and their preferred vocabulary are summarized in [key_competencies.md](key_competencies.md).
+
 | Term | Form | Notes |
 | --- | --- | --- |
 | pod | lowercase | The cross-functional team. Not "team," "squad," or "group." |


### PR DESCRIPTION
Update the progression docs, being-a pages, JDs, and engineering principles to reflect language from the company's Key Competencies guide. Additions cover Change Management (new section and bullets), Integrity & Ethics, Business Acumen (KPIs framing), and Contextual Communication. The principles page is updated to explicitly bridge the engineering principles to the Key Competencies framework.